### PR TITLE
[docker] ensure that Dockerfile.gen matches Dockerfile

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile.gen

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,10 +67,10 @@ RUN cd _deps/repo-ft-src/ && \
     rm /workspace/build/fastertransformer_backend/build/bin/*_example -rf && \
     rm /workspace/build/fastertransformer_backend/build/lib/lib*Backend.so -rf
 
-ENV NCCL_LAUNCH_MODE=GROUP
 ENV WORKSPACE /workspace
 WORKDIR /workspace
 
+ENV NCCL_LAUNCH_MODE=GROUP
 RUN sed -i 's/#X11UseLocalhost yes/X11UseLocalhost no/g' /etc/ssh/sshd_config && \
     mkdir /var/run/sshd -p
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,8 @@
+Dockerfile: Dockerfile.gen
+	cp $< $@
+
+Dockerfile.gen: create_dockerfile_and_build.py
+	python create_dockerfile_and_build.py \
+		--triton-version 22.12 \
+		--dry-run
+


### PR DESCRIPTION
There was support added for a new GPU architecture(https://github.com/TabbyML/tabby/issues/62) and I noticed this
python script wasn't updated. I Figured it would be good to ensure IF
this python script was used somewhere else, unexpectedly, that it should
also output the additional GPU arch.

Followup for commit 1db2fc8255dad63521e2001c2b78b633f90c1fbc

The output from this python script now matches the existing Dockerfile that is checked into the repo.

```shell
❯ rm Dockerfile.gen && make Dockerfile.gen && diff -u Dockerfile Dockerfile.gen
python create_dockerfile_and_build.py \
	--triton-version 22.12 \
	--dry-run

Sat Apr  8 20:56:51 2023 exit 0 🟢
```
