### PR TITLE
Reduce docker image size

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+Makefile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,10 @@
 
 ARG TRITON_VERSION=22.12
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
-FROM ${BASE_IMAGE}
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+FROM ${BASE_IMAGE} AS aptdeps
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
         autoconf \
         autogen \
         clangd \
@@ -35,17 +35,22 @@ RUN apt-get install -y --no-install-recommends \
         unzip \
         zstd \
         zip \
-        zsh
-RUN pip3 install torch==1.12.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html && \
+        zsh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM aptdeps AS pytorch
+
+RUN --mount=type=cache,id=pipcache,target=/root/.cache/pip \
+    pip3 install torch==1.12.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html && \
     pip3 install --extra-index-url https://pypi.ngc.nvidia.com regex fire tritonclient[all] && \
     pip3 install transformers huggingface_hub tokenizers SentencePiece sacrebleu datasets tqdm omegaconf rouge_score && \
     pip3 install cmake==3.24.3
 
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # backend build
-ADD . /workspace/build/fastertransformer_backend
+FROM pytorch AS backend
+
+ADD --link . /workspace/build/fastertransformer_backend
 RUN mkdir -p /workspace/build/fastertransformer_backend/build
 
 WORKDIR /workspace/build/fastertransformer_backend/build
@@ -60,12 +65,15 @@ RUN cmake \
       -D TRITON_CORE_REPO_TAG="r${NVIDIA_TRITON_SERVER_VERSION}" \
       -D TRITON_BACKEND_REPO_TAG="r${NVIDIA_TRITON_SERVER_VERSION}" \
       ..
+
 RUN cd _deps/repo-ft-src/ && \
     git log | head -n 3 2>&1 | tee /workspace/build/fastertransformer_backend/FT_version.txt && \
     cd /workspace/build/fastertransformer_backend/build && \
     make -j"$(grep -c ^processor /proc/cpuinfo)" install && \
     rm /workspace/build/fastertransformer_backend/build/bin/*_example -rf && \
     rm /workspace/build/fastertransformer_backend/build/lib/lib*Backend.so -rf
+
+FROM backend AS final
 
 ENV NCCL_LAUNCH_MODE=GROUP
 ENV WORKSPACE /workspace

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,29 @@
+build: Dockerfile
+	docker build \
+		-t tabbyml/fastertransformer_backend:latest \
+		-f $< \
+		..
+
+build_aptdeps: Dockerfile
+	docker build --target aptdeps \
+		-t tabbyml/fastertransformer_backend:aptdeps \
+		-f $< \
+		..
+
+build_pytorch: Dockerfile
+	docker build --target pytorch \
+		-t tabbyml/fastertransformer_backend:pytorch \
+		-f $< \
+		..
+
+build_backend: Dockerfile
+	docker build --target backend \
+		-t tabbyml/fastertransformer_backend:backend \
+		-f $< \
+		..
+
+build_final: Dockerfile
+	docker build --target final \
+		-t tabbyml/fastertransformer_backend:final \
+		-f $< \
+		..


### PR DESCRIPTION
The resulting docker image is smaller by about 2GB, mostly from removing the pipcache from the pytorch installation. I've added the Makefile and multi-stage targets that I used to built images after each significant step where I used the `dive` command to inspect what parts of the image could be removed.

```
tabbyml/fastertransformer_backend  latest   fa652de9cf14  5   days   ago  25.7GB

tabbyml/fastertransformer_backend  final    d50ee33898ca  18  hours  ago  23.7GB
tabbyml/fastertransformer_backend  backend  889094e0d0a0  19  hours  ago  23.7GB
tabbyml/fastertransformer_backend  pytorch  ad179079aa04  20  hours  ago  18.6GB
tabbyml/fastertransformer_backend  aptdeps  fef8f465808c  20  hours  ago  14.6GB
```

The backend stage could likely still have some things removed as well, as `/workspcae/**/build` directories probably don't need to be kept in the image; but I need to inspect the downstream Dockerfile in `tabbyML/tabby` to confirm this.
